### PR TITLE
update csv saving

### DIFF
--- a/skellymodels/experimental/model_redo/biomechanics/anatomical_calculations.py
+++ b/skellymodels/experimental/model_redo/biomechanics/anatomical_calculations.py
@@ -59,10 +59,7 @@ class RigidBonesEnforcement(AnatomicalCalculation):
 
         rigid_marker_data = enforce_rigid_bones(
             marker_trajectories=trajectory.data,
-            segment_3d_positions=trajectory.segment_data,
-            segment_conections=trajectory._segment_connections, #segment connections could also come from anatomical structures. there's some figuring out to do here
             joint_hierarchy= aspect.anatomical_structure.joint_hierarchy
-
         )
 
         return CalculationResult(

--- a/skellymodels/experimental/model_redo/biomechanics/anatomical_calculations.py
+++ b/skellymodels/experimental/model_redo/biomechanics/anatomical_calculations.py
@@ -72,10 +72,8 @@ class RigidBonesEnforcement(AnatomicalCalculation):
         if not results.success:
             return
         
-        aspect.add_trajectory(
-            name='rigid_3d_xyz', 
-            data=results.data['rigid_bones'], 
-            marker_names=aspect.anatomical_structure.marker_names
+        aspect.add_rigid_body_data(
+            rigid_body_data=results.data['rigid_bones']
         )
 
 

--- a/skellymodels/experimental/model_redo/biomechanics/calculations/enforce_rigid_bones.py
+++ b/skellymodels/experimental/model_redo/biomechanics/calculations/enforce_rigid_bones.py
@@ -1,46 +1,66 @@
 from copy import deepcopy
 import numpy as np
-from typing import Dict, List, Union
+from typing import Dict, List, Union,Tuple
+from collections import deque
 
+
+# def calculate_bone_lengths_and_statistics(
+#     segment_data: Dict[str, Dict[str, np.ndarray]]
+# ) -> Dict[str, Dict[str, Union[np.ndarray, float]]]:
+#     """
+#     Calculates bone lengths for each frame and their statistics (median and standard deviation)
+#     based on marker positions and segment connections.
+
+#     Parameters:
+#     - segment_data: A dictionary defining the segments (bones) with segment names as keys
+#       and dictionaries with 'proximal' and 'distal' marker xyz locations as values.
+
+#     Returns:
+#     - A dictionary with segment names as keys and dictionaries with lengths, median lengths,
+#       and standard deviations as values.
+#     """
+#     bone_statistics = {}
+
+#     for segment_name, segment in segment_data.items():
+#         proximal_positions = segment['proximal']
+#         distal_positions = segment['distal']
+
+#         lengths = np.linalg.norm(distal_positions - proximal_positions, axis=1)
+
+#         median_length = np.nanmedian(lengths)
+#         stdev_length = np.nanstd(lengths)
+
+#         bone_statistics[segment_name] = {
+#             "lengths": lengths, 
+#             "median": median_length, 
+#             "stdev": stdev_length
+#         }
+
+#     return bone_statistics
 
 def calculate_bone_lengths_and_statistics(
-    marker_data: Dict[str, np.ndarray], 
-    segment_data: Dict[str, Dict[str, np.ndarray]]
-) -> Dict[str, Dict[str, Union[np.ndarray, float]]]:
-    """
-    Calculates bone lengths for each frame and their statistics (median and standard deviation)
-    based on marker positions and segment connections.
+        marker_trajectories: Dict[str, np.ndarray],
+        joint_hierarchy: Dict[str, List[str]],
+) -> Dict[Tuple[str, str], Dict[str, float]]:
+    bone_stats = {}
+    for parent, children in joint_hierarchy.items():
+        parent_xyz = marker_trajectories[parent]
+        print(f"\nBone lengths from '{parent}' to:")
 
-    Parameters:
-    - marker_data: A dictionary containing marker trajectories with marker names as keys and
-      3D positions as values (numpy arrays).
-    - segment_connections: A dictionary defining the segments (bones) with segment names as keys
-      and dictionaries with 'proximal' and 'distal' markers as values.
+        for child in children:
+            child_xyz = marker_trajectories[child]
+            lengths = np.linalg.norm(child_xyz - parent_xyz, axis=1)
 
-    Returns:
-    - A dictionary with segment names as keys and dictionaries with lengths, median lengths,
-      and standard deviations as values.
-    """
-    bone_statistics = {}
+            median = np.nanmedian(lengths)
+            stdev  = np.nanstd(lengths)
 
-    for segment_name, segment in segment_data.items():
-        proximal_positions = segment['proximal']
-        distal_positions = segment['distal']
+            bone_stats[(parent, child)] = {
+                "median": median,
+                "stdev":  stdev,
+            }
 
-        lengths = np.linalg.norm(distal_positions - proximal_positions, axis=1)
-        valid_lengths = lengths[~np.isnan(lengths)]
-
-        median_length = np.median(valid_lengths)
-        stdev_length = np.std(valid_lengths)
-
-        bone_statistics[segment_name] = {
-            "lengths": lengths, 
-            "median": median_length, 
-            "stdev": stdev_length
-        }
-
-    return bone_statistics
-
+            print(f"  - '{child}': median = {median:.2f}, stdev = {stdev:.2f}")
+    return bone_stats
 
 def rigidify_bones(
     marker_data: Dict[str, np.ndarray],
@@ -70,14 +90,20 @@ def rigidify_bones(
         proximal_marker, distal_marker = segment['proximal'], segment['distal']
 
         for frame_index, current_length in enumerate(lengths):
-            if current_length != desired_length:
-                proximal_position = marker_data[proximal_marker][frame_index]
-                distal_position = marker_data[distal_marker][frame_index]
+            if np.isnan(current_length) or current_length < 1e-10:
+                continue
+            if abs(current_length - desired_length) > 1e-6:
+                proximal_position = rigid_marker_data[proximal_marker][frame_index]
+                distal_position = rigid_marker_data[distal_marker][frame_index]
                 direction = distal_position - proximal_position
                 try:
-                    direction /= np.linalg.norm(direction)  # Normalize to unit vector
-                except ZeroDivisionError:
-                    direction /= 1e-5  # Set to a small value if the direction is zero
+                    norm = np.linalg.norm(direction)
+                    if norm < 1e-10:  # If effectively zero
+                        direction = np.array([0.0, 0.0, 1.0])  # Use a default direction
+                    else:
+                        direction = direction / norm  # Proper normalization
+                except:
+                    direction = np.array([0.0, 0.0, 1.0])  # Fallback to default
                 adjustment = (desired_length - current_length) * direction
 
                 rigid_marker_data[distal_marker][frame_index] += adjustment
@@ -118,22 +144,60 @@ def merge_rigid_marker_data(rigid_marker_data: Dict[str, np.ndarray]) -> np.ndar
 
     return np.stack(rigid_marker_data_list, axis=1)
 
+
+
+def rigidify_forward_pass(
+        marker_trajectories: Dict[str, np.ndarray],
+        joint_hierarchy: Dict[str, List[str]],
+        bone_stats: Dict[str, Dict[str, Union[np.ndarray, float]]],
+):
+    marker_names = list(marker_trajectories.keys())
+    data = np.stack([marker_trajectories[n] for n in marker_names], axis=1)
+    num_frames, num_markers, _ = data.shape
+
+    root = next(iter(joint_hierarchy)) 
+    edge_connections, queue = [], deque([root])
+    while queue:
+        parent = queue.popleft()
+        for child in joint_hierarchy.get(parent, []):
+            edge_connections.append((parent, child))
+            queue.append(child)
+
+    rigid_data = data.copy()
+    for frame in range(num_frames):
+        frame_data = rigid_data[frame]
+        direction_vector = np.array([1.0,0.0,0.0])
+
+        for parent, child in edge_connections:
+            parent_index, child_index = marker_names.index(parent), marker_names.index(child)
+            vector = frame_data[child_index] - frame_data[parent_index]
+            norm = np.linalg.norm(vector)
+            if np.isfinite(norm) and norm > 1e-6:
+                direction_vector = vector/norm
+            rigid_length = bone_stats[(parent,child)]["median"]
+            frame_data[child_index] = frame_data[parent_index] + direction_vector*rigid_length
+
+    return {name: rigid_data[:, i, :] for i, name in enumerate(marker_names)}
+
+
+
+
+    
+
 def enforce_rigid_bones(marker_trajectories:np.ndarray,
-                        segment_3d_positions:Dict[str, Dict[str, np.ndarray]],
-                        segment_conections: Dict[str, Dict[str, str]],
                         joint_hierarchy: Dict[str, List[str]]
                         ):
     
     bone_lengths_and_statistics = calculate_bone_lengths_and_statistics(
-        marker_data = marker_trajectories,
-        segment_data = segment_3d_positions
-    )
-
-    rigid_marker_data = rigidify_bones(
-        marker_data=marker_trajectories,
-        segment_connections=segment_conections,
-        bone_lengths_and_statistics= bone_lengths_and_statistics,
+        marker_trajectories=marker_trajectories,
         joint_hierarchy=joint_hierarchy
     )
 
+    rigid_marker_data = rigidify_forward_pass(
+        marker_trajectories=marker_trajectories,
+        bone_stats=bone_lengths_and_statistics,
+        joint_hierarchy=joint_hierarchy
+    )
+    
+    f = 2
     return merge_rigid_marker_data(rigid_marker_data)

--- a/skellymodels/experimental/model_redo/managers/actor.py
+++ b/skellymodels/experimental/model_redo/managers/actor.py
@@ -76,6 +76,7 @@ class Actor(ABC):
     def from_landmarks_numpy_array(cls, name:str, model_info:ModelInfo, landmarks_numpy_array:np.ndarray):
         actor = cls(name=name, model_info = model_info)
         actor.add_landmarks_numpy_array(landmarks_numpy_array=landmarks_numpy_array)
+        return actor
 
     def calculate(self, pipeline:CalculationPipeline = STANDARD_PIPELINE):
         for aspect in self.aspects.values():

--- a/skellymodels/experimental/model_redo/managers/actor.py
+++ b/skellymodels/experimental/model_redo/managers/actor.py
@@ -132,7 +132,7 @@ class Actor(ABC):
             for trajectory in aspect.trajectories.values():
                 save_path = path_to_output_folder / f"{aspect.metadata['tracker_type']}_{aspect.name}_{trajectory.name}.npy"
                 np.save(save_path,
-                        trajectory.data)  # TODO: the .data is throwing a type error because this is sometimes a dict instead of an array
+                        trajectory.as_numpy)  # TODO: the .data is throwing a type error because this is sometimes a dict instead of an array
                 print(f"Saved out {save_path}")
 
     def save_out_csv_data(self, path_to_output_folder: Optional[Path] = None):

--- a/skellymodels/experimental/model_redo/managers/actor.py
+++ b/skellymodels/experimental/model_redo/managers/actor.py
@@ -82,7 +82,7 @@ class Actor(ABC):
 
                 if not trajectory_name == 'rigid_3d_xyz': #NOTE: 03/04/25 - excluding rigid body trajectories for the moment because I think they'll be handled different enough in the final version that its not worth including at the moment
                      # Convert trajectory to a DataFrame
-                    trajectory_df = trajectory.as_dataframe.copy()
+                    trajectory_df = trajectory.as_dataframe
                     
                     # Add metadata columns
                     trajectory_df['model'] = f"{aspect.metadata['tracker_type']}.{aspect_name}"

--- a/skellymodels/experimental/model_redo/managers/human.py
+++ b/skellymodels/experimental/model_redo/managers/human.py
@@ -17,7 +17,9 @@ class Human(Actor):
         super().__init__(name)
         
         self.tracker = model_info.name
-        self.aspect_order = model_info.aspect_order_and_slices
+        self.aspect_order = model_info.order
+        self.tracked_point_slices = model_info.tracked_point_slices
+        self.landmark_slices = model_info.landmark_slices
         self.model_info = model_info
         
         self._initialize_aspects()
@@ -29,13 +31,13 @@ class Human(Actor):
         """
         self._add_body()
 
-        if HumanAspectNames.FACE.value in self.aspect_order.keys():
+        if HumanAspectNames.FACE.value in self.aspect_order:
             self._add_face()
 
-        if HumanAspectNames.LEFT_HAND.value in self.aspect_order.keys():
+        if HumanAspectNames.LEFT_HAND.value in self.aspect_order:
             self._add_left_hand()
         
-        if HumanAspectNames.RIGHT_HAND.value in self.aspect_order.keys():
+        if HumanAspectNames.RIGHT_HAND.value in self.aspect_order:
             self._add_right_hand()
 
     def _add_body(self):
@@ -82,31 +84,60 @@ class Human(Actor):
     @property
     def right_hand(self):
         return self.aspects.get(HumanAspectNames.RIGHT_HAND.value)
-
+    
     def add_tracked_points_numpy(self, tracked_points_numpy_array:np.ndarray):
         """
         Takes in the tracked points array, splits and categorizes it based on the ranges determined by the ModelInfo,
         and adds it as a tracked point Trajectory to the body, and optionally face/hands aspects 
         """
-        self.body.add_tracked_points(tracked_points_numpy_array[:,self.aspect_order[HumanAspectNames.BODY.value],:])
 
-        if HumanAspectNames.FACE.value in self.aspect_order.keys() and self.face is not None:
-            self.face.add_tracked_points(tracked_points_numpy_array[:,self.aspect_order[HumanAspectNames.FACE.value],:])
+        self.body.add_tracked_points(tracked_points_numpy_array[:,self.tracked_point_slices[HumanAspectNames.BODY.value],:])
 
-        if HumanAspectNames.LEFT_HAND.value in self.aspect_order.keys() and self.left_hand is not None:
-            self.left_hand.add_tracked_points(tracked_points_numpy_array[:,self.aspect_order[HumanAspectNames.LEFT_HAND.value],:])
+        if HumanAspectNames.FACE.value in self.tracked_point_slices and self.face is not None:
+            self.face.add_tracked_points(
+                tracked_points_numpy_array[:,self.tracked_point_slices[HumanAspectNames.FACE.value],:]
+                )
+            
+        if HumanAspectNames.LEFT_HAND.value in self.tracked_point_slices and self.left_hand is not None:
+            self.left_hand.add_tracked_points(
+                tracked_points_numpy_array[:,self.tracked_point_slices[HumanAspectNames.LEFT_HAND.value],:]
+                )
         
-        if HumanAspectNames.RIGHT_HAND.value in self.aspect_order.keys() and self.right_hand is not None:
-            self.right_hand.add_tracked_points(tracked_points_numpy_array[:,self.aspect_order[HumanAspectNames.RIGHT_HAND.value],:])
+        if HumanAspectNames.RIGHT_HAND.value in self.tracked_point_slices and self.right_hand is not None:
+            self.right_hand.add_tracked_points(
+                tracked_points_numpy_array[:,self.tracked_point_slices[HumanAspectNames.RIGHT_HAND.value],:]
+                )
+        
+    def add_landmarks_numpy_array(self, landmarks_numpy_array:np.ndarray):
+        """
+        Takes in landmark data, splits and categorizes it based on the ranges determined by the ModelInfo,
+        and adds it as a tracked point Trajectory to the body, and optionally face/hands aspects 
+        """
+        self.body.add_landmarks(landmarks_numpy_array[:,self.landmark_slices[HumanAspectNames.BODY.value],:])
+
+        if HumanAspectNames.FACE.value in self.landmark_slices and self.face is not None:
+            self.face.add_landmarks(
+                landmarks_numpy_array[:,self.landmark_slices[HumanAspectNames.FACE.value],:]
+                )
+        
+        if HumanAspectNames.LEFT_HAND.value in self.landmark_slices and self.left_hand is not None:
+            self.left_hand.add_landmarks(
+                landmarks_numpy_array[:,self.landmark_slices[HumanAspectNames.LEFT_HAND.value],:]
+                )
+
+        if HumanAspectNames.RIGHT_HAND.value in self.landmark_slices and self.right_hand is not None:
+            self.right_hand.add_landmarks(
+                landmarks_numpy_array[:,self.landmark_slices[HumanAspectNames.RIGHT_HAND.value],:]
+                )
 
     def add_reprojection_error_numpy(self, reprojection_error_data: np.ndarray):
-        self.body.add_reprojection_error(reprojection_error_data[:,self.aspect_order[HumanAspectNames.BODY.value]])
+        self.body.add_reprojection_error(reprojection_error_data[:, self.tracked_point_slices[HumanAspectNames.BODY.value]])
 
-        if HumanAspectNames.FACE.value in self.aspect_order.keys() and self.face is not None:
-            self.face.add_reprojection_error(reprojection_error_data[:,self.aspect_order[HumanAspectNames.FACE.value]])
+        if HumanAspectNames.FACE.value in self.tracked_point_slices and self.face is not None:
+            self.face.add_reprojection_error(reprojection_error_data[:, self.tracked_point_slices[HumanAspectNames.FACE.value]])
         
-        if HumanAspectNames.LEFT_HAND.value in self.aspect_order.keys() and self.left_hand is not None:
-            self.left_hand.add_reprojection_error(reprojection_error_data[:,self.aspect_order[HumanAspectNames.LEFT_HAND.value]])
-
-        if HumanAspectNames.RIGHT_HAND.value in self.aspect_order.keys() and self.right_hand is not None:
-            self.right_hand.add_reprojection_error(reprojection_error_data[:,self.aspect_order[HumanAspectNames.RIGHT_HAND.value]])
+        if HumanAspectNames.LEFT_HAND.value in self.tracked_point_slices and self.left_hand is not None:
+            self.left_hand.add_reprojection_error(reprojection_error_data[:, self.tracked_point_slices[HumanAspectNames.LEFT_HAND.value]])
+        
+        if HumanAspectNames.RIGHT_HAND.value in self.tracked_point_slices and self.right_hand is not None:
+            self.right_hand.add_reprojection_error(reprojection_error_data[:, self.tracked_point_slices[HumanAspectNames.RIGHT_HAND.value]])

--- a/skellymodels/experimental/model_redo/mediapipe_human_example.py
+++ b/skellymodels/experimental/model_redo/mediapipe_human_example.py
@@ -25,7 +25,6 @@ pprint([human.aspects])
 
 human.calculate() #does our COM/Rigid bones calculations
 
-
 human.save_out_numpy_data()
 human.save_out_csv_data()
 human.save_out_all_data_csv()

--- a/skellymodels/experimental/model_redo/mediapipe_human_example.py
+++ b/skellymodels/experimental/model_redo/mediapipe_human_example.py
@@ -24,6 +24,13 @@ human.add_tracked_points_numpy(tracked_points_numpy_array=data)
 pprint([human.aspects])
 
 human.calculate() #does our COM/Rigid bones calculations
+
+
+human.save_out_numpy_data()
+human.save_out_csv_data()
+human.save_out_all_data_csv()
+human.save_out_all_data_parquet()
+
 f = 2
 # pprint([human.aspects])
 

--- a/skellymodels/experimental/model_redo/mediapipe_rigid_bones_testing.py
+++ b/skellymodels/experimental/model_redo/mediapipe_rigid_bones_testing.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import numpy as np
+
+from skellymodels.experimental.model_redo.managers.human import Human
+
+from pprint import pprint
+
+from skellymodels.experimental.model_redo.tracker_info.model_info import MediapipeModelInfo
+
+
+model_info = MediapipeModelInfo()
+
+## Choose a path to the directory 
+path_to_data = Path(r"C:\Users\aaron\FreeMocap_Data\recording_sessions\freemocap_test_data\output_data\raw_data\mediapipe_3dData_numFrames_numTrackedPoints_spatialXYZ.npy")
+data = np.load(path_to_data)
+
+## Create an Actor
+human = Human(
+            name="human_one", 
+            model_info=model_info
+            )
+
+human.add_tracked_points_numpy(tracked_points_numpy_array=data)
+pprint([human.aspects])
+
+human.calculate() #does our COM/Rigid bones calculations
+    
+# human.save_out_numpy_data()
+# human.save_out_csv_data()
+# human.save_out_all_data_csv()
+# human.save_out_all_data_parquet()
+
+f = 2
+# pprint([human.aspects])
+

--- a/skellymodels/experimental/model_redo/models/aspect.py
+++ b/skellymodels/experimental/model_redo/models/aspect.py
@@ -97,6 +97,13 @@ class Aspect:
         self.add_trajectory(name='segment_com',
                             data=segment_center_of_mass,
                             marker_names=list(self.anatomical_structure.center_of_mass_definitions.keys()))
+        
+    def add_rigid_body_data(self, rigid_body_data: np.ndarray):
+        self.add_trajectory(name = "rigid_3d_xyz",
+                            data = rigid_body_data,
+                            marker_names = self.anatomical_structure.marker_names,
+                            segment_connections = self.anatomical_structure.segment_connections
+                            )
 
     def add_reprojection_error(self, reprojection_error_data: np.ndarray):
         # TODO: This could be a feature of the trajectory as well, but I'm leaning towards aspect taking care of it

--- a/skellymodels/experimental/model_redo/models/aspect.py
+++ b/skellymodels/experimental/model_redo/models/aspect.py
@@ -69,7 +69,7 @@ class Aspect:
         
         self.add_trajectory(name='3d_xyz',
                             data=landmarks_numpy_array,
-                            marker_names=self.anatomical_structure.tracked_point_names,
+                            marker_names=self.anatomical_structure.marker_names,
                             segment_connections=self.anatomical_structure.segment_connections)
         
     def add_tracked_points(self, tracked_points: np.ndarray):

--- a/skellymodels/experimental/model_redo/models/aspect.py
+++ b/skellymodels/experimental/model_redo/models/aspect.py
@@ -66,36 +66,37 @@ class Aspect:
         """Adding all markers (virtual markers included) to model"""
         if self.anatomical_structure is None or self.anatomical_structure.tracked_point_names is None:
             raise ValueError("Anatomical structure and tracked point names are required to add landmark data")
-        self.trajectories['3d_xyz'] = Trajectory(name = '3d_xyz',
-                                                 data = landmarks_numpy_array,
-                                                 marker_names = self.anatomical_structure.marker_names,
-                                                 segment_connections=self.anatomical_structure.segment_connections,
-                                                 )
-
+        
+        self.add_trajectory(name='3d_xyz',
+                            data=landmarks_numpy_array,
+                            marker_names=self.anatomical_structure.tracked_point_names,
+                            segment_connections=self.anatomical_structure.segment_connections)
+        
     def add_tracked_points(self, tracked_points: np.ndarray):
         """Use tracked points to calculate trajectories, using virtual markers if included"""
         if self.anatomical_structure is None or self.anatomical_structure.tracked_point_names is None:
             raise ValueError("Anatomical structure and tracked point names are required to add tracked points.")
-        self.trajectories['3d_xyz'] = Trajectory(name="3d_xyz",
-                                                 data=tracked_points,
-                                                 marker_names=self.anatomical_structure.tracked_point_names,
-                                                 virtual_marker_definitions=self.anatomical_structure.virtual_markers_definitions,
-                                                 segment_connections=self.anatomical_structure.segment_connections)
+        
+        self.add_trajectory(name = '3d_xyz',
+                            data = tracked_points,
+                            marker_names = self.anatomical_structure.tracked_point_names,
+                            virtual_marker_definitions = self.anatomical_structure.virtual_markers_definitions,
+                            segment_connections = self.anatomical_structure.segment_connections)
 
     def add_total_body_center_of_mass(self, total_body_center_of_mass: np.ndarray):
-        self.trajectories['total_body_com'] = Trajectory(name='total_body_com',
-                                                         data=total_body_center_of_mass,
-                                                         marker_names=['total_body_com']
-                                                         )
+
+        self.add_trajectory(name='total_body_com',
+                            data=total_body_center_of_mass,
+                            marker_names=['total_body_com']
+                            )
 
     def add_segment_center_of_mass(self, segment_center_of_mass: np.ndarray):
         if self.anatomical_structure is None or self.anatomical_structure.center_of_mass_definitions is None:
             raise ValueError(
                 "Anatomical structure and center of mass definitions are required to add segment center of mass.")
-        self.trajectories['segment_com'] = Trajectory(name='segment_com',
-                                                      data=segment_center_of_mass,
-                                                      marker_names=list(
-                                                          self.anatomical_structure.center_of_mass_definitions.keys()))
+        self.add_trajectory(name='segment_com',
+                            data=segment_center_of_mass,
+                            marker_names=list(self.anatomical_structure.center_of_mass_definitions.keys()))
 
     def add_reprojection_error(self, reprojection_error_data: np.ndarray):
         # TODO: This could be a feature of the trajectory as well, but I'm leaning towards aspect taking care of it

--- a/skellymodels/experimental/model_redo/models/aspect.py
+++ b/skellymodels/experimental/model_redo/models/aspect.py
@@ -61,6 +61,16 @@ class Aspect:
                                              marker_names=marker_names,
                                              virtual_marker_definitions=virtual_marker_definitions,
                                              segment_connections=segment_connections)
+        
+    def add_landmarks(self, landmarks_numpy_array: np.ndarray):
+        """Adding all markers (virtual markers included) to model"""
+        if self.anatomical_structure is None or self.anatomical_structure.tracked_point_names is None:
+            raise ValueError("Anatomical structure and tracked point names are required to add landmark data")
+        self.trajectories['3d_xyz'] = Trajectory(name = '3d_xyz',
+                                                 data = landmarks_numpy_array,
+                                                 marker_names = self.anatomical_structure.marker_names,
+                                                 segment_connections=self.anatomical_structure.segment_connections,
+                                                 )
 
     def add_tracked_points(self, tracked_points: np.ndarray):
         """Use tracked points to calculate trajectories, using virtual markers if included"""

--- a/skellymodels/experimental/model_redo/models/trajectory.py
+++ b/skellymodels/experimental/model_redo/models/trajectory.py
@@ -12,7 +12,7 @@ class TrajectoryValidator(BaseModel):
     @model_validator(mode="after")
     def validate_data(self):
         if self.data.shape[1] != len(self.marker_names):
-            raise ValueError(f"Trajectory data must have the same number of markers as input name list. Data has {self.data.shape[1]} markers and list has {len(self.marker_names)} markers.")
+            raise ValueError(f"Trajectory data must have the same number of markers as input name list. Data has shape {self.data.shape} and list has {len(self.marker_names)} markers.")
 
     
 
@@ -71,6 +71,10 @@ class Trajectory:
             
             self._marker_names += list(virtual_marker_data.keys())
             self._trajectories.update(virtual_marker_data)
+
+    @property
+    def landmark_names(self):
+        return self._marker_names
 
     @property
     def data(self):  # TODO: elsewhere this is used for the numpy array, but here its a dictionary 

--- a/skellymodels/experimental/model_redo/rigid_bones_testing.py
+++ b/skellymodels/experimental/model_redo/rigid_bones_testing.py
@@ -1,0 +1,371 @@
+from pathlib import Path
+import numpy as np
+from typing import Dict, List, Union, Optional
+import matplotlib.pyplot as plt
+
+from skellymodels.experimental.model_redo.managers.human import Human
+from skellymodels.experimental.model_redo.tracker_info.model_info import MediapipeModelInfo
+
+
+def create_segment_data(
+    trajectory_data: Dict[str, np.ndarray],
+    segment_connections: Dict[str, Dict[str, str]]
+) -> Dict[str, Dict[str, np.ndarray]]:
+    """
+    Creates segment data in the format expected by check_all_rigid_segments from
+    a dictionary of trajectories.
+    
+    Parameters:
+        trajectory_data: Dictionary where keys are marker names and values are position arrays
+        segment_connections: Dictionary defining segment connections with format
+                            {segment_name: {'proximal': marker1, 'distal': marker2}}
+    
+    Returns:
+        segment_data: Dictionary {segment_name: {'proximal': positions, 'distal': positions}}
+                     ready for use in check_all_rigid_segments
+    """
+    segment_data = {}
+    
+    for segment_name, connection in segment_connections.items():
+        proximal_marker = connection['proximal']
+        distal_marker = connection['distal']
+        
+        # Skip if markers don't exist in the data
+        if proximal_marker not in trajectory_data or distal_marker not in trajectory_data:
+            print(f"Warning: Segment {segment_name} uses markers {proximal_marker} and/or {distal_marker} which are not in the data. Skipping.")
+            continue
+        
+        segment_data[segment_name] = {
+            'proximal': trajectory_data[proximal_marker],
+            'distal': trajectory_data[distal_marker]
+        }
+    
+    return segment_data
+
+
+def check_all_rigid_segments(segment_data, tolerance=0.001):
+    """
+    Checks whether all rigid body segments maintain constant length over time.
+    
+    Parameters:
+        segment_data (dict): Dictionary where each key is a segment name, 
+                             and each value contains 'proximal' and 'distal' arrays.
+        tolerance (float): Allowed variation in segment length (default 1mm, or 0.001m).
+    
+    Returns:
+        dict: A dictionary containing analysis results for each segment.
+    """
+    results = {}
+
+    for segment_name, segment in segment_data.items():
+        proximal = np.array(segment['proximal'])  # Shape: (n_frames, 3)
+        distal = np.array(segment['distal'])      # Shape: (n_frames, 3)
+
+        if proximal.shape != distal.shape:
+            raise ValueError(f"Mismatch in proximal/distal shape for segment {segment_name}")
+
+        # Compute Euclidean distance for each frame
+        segment_lengths = np.linalg.norm(proximal - distal, axis=1)
+        
+        # Get both reference methods
+        expected_length = segment_lengths[0]  # First frame as reference (original method)
+        mean_length = np.nanmean(segment_lengths)
+        
+        # Compute statistics
+        deviations = np.abs(segment_lengths - expected_length)
+        max_change = np.nanmax(deviations)
+        std_deviation = np.nanstd(segment_lengths)
+        cv = (std_deviation / mean_length) * 100  # Coefficient of variation in percent
+        absolute_range = np.max(segment_lengths) - np.min(segment_lengths)
+
+        # Check if any deviation exceeds the tolerance
+        violates_rigidity = np.any(deviations > tolerance)
+        violates_cv = cv > 0.5  # Using 0.5% CV as threshold
+
+        results[segment_name] = {
+            "lengths": segment_lengths,
+            "expected_length": expected_length,
+            "mean_length": mean_length,
+            "max_change": max_change,
+            "std_deviation": std_deviation,
+            "cv": cv,
+            "absolute_range": absolute_range,
+            "violates_rigidity": violates_rigidity,
+            "violates_cv": violates_cv
+        }
+
+    return results
+
+
+def visualize_rigid_bones_results(results, tolerance=0.001, cv_threshold=0.5):
+    """Creates visualizations for rigid bones test results"""
+    
+    # Sort segments by maximum change (most problematic first)
+    sorted_segments = sorted(results.items(), key=lambda x: x[1]['max_change'], reverse=True)
+    
+    # Create visualization
+    plt.figure(figsize=(15, 12))
+    plt.suptitle("Bone Length Stability Across Frames", fontsize=16)
+
+    # Plot 1: Top 5 most variable segments + spine
+    plt.subplot(2, 1, 1)
+    # Always include the spine if it exists
+    spine_included = False
+    for i, (segment_name, segment_results) in enumerate(sorted_segments[:5]):
+        plt.plot(segment_results['lengths'], label=f"{segment_name} (max dev: {segment_results['max_change']:.4f})")
+        if segment_name == 'spine':
+            spine_included = True
+
+    # Add spine if it wasn't in the top 5
+    if not spine_included and 'spine' in results:
+        spine_results = results['spine']
+        plt.plot(spine_results['lengths'], 'k--', linewidth=2, 
+                 label=f"spine (max dev: {spine_results['max_change']:.4f})")
+
+    plt.title("Segments with Largest Deviations from First Frame")
+    plt.xlabel("Frame")
+    plt.ylabel("Length (units)")
+    plt.legend()
+    plt.grid(True, alpha=0.3)
+
+    # Plot 2: Maximum change for all segments
+    plt.subplot(2, 1, 2)
+    segment_names = [s[0] for s in sorted_segments]
+    max_changes = [s[1]['max_change'] for s in sorted_segments]
+
+    bars = plt.bar(segment_names, max_changes)
+    plt.xticks(rotation=90)
+    plt.title("Maximum Deviation from First Frame for Each Segment")
+    plt.ylabel("Maximum Deviation (units)")
+    plt.axhline(y=tolerance, color='r', linestyle='--', label=f"{tolerance}m Threshold")
+    plt.legend()
+    plt.grid(True, axis='y', alpha=0.3)
+
+    # Highlight bars based on max_change value
+    # Find the spine index if it exists
+    spine_index = -1
+    for i, name in enumerate(segment_names):
+        if name == 'spine':
+            spine_index = i
+            break
+
+    # Highlight the bars
+    for i, max_change in enumerate(max_changes):
+        if i == spine_index:
+            # Highlight spine in a unique color (blue)
+            bars[i].set_color('royalblue') 
+            bars[i].set_edgecolor('navy')
+            bars[i].set_linewidth(2)
+        elif max_change > tolerance:
+            bars[i].set_color('r')
+        else:
+            bars[i].set_color('g')
+
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+
+    # Create a summary table of statistics
+    plt.figure(figsize=(12, 8))
+    plt.axis('off')
+    plt.title("Segment Length Statistics", fontsize=16)
+
+    # Create table data
+    table_data = []
+    headers = ["Segment", "First Frame", "Mean Length", "Max Dev", "CV (%)", "Rigid 1mm?", "Rigid CV?"]
+
+    for segment_name, segment_results in sorted_segments:
+        is_rigid_abs = "Yes" if segment_results['max_change'] < tolerance else "No"
+        is_rigid_cv = "Yes" if segment_results['cv'] < cv_threshold else "No"
+        
+        table_data.append([
+            segment_name, 
+            f"{segment_results['expected_length']:.4f}", 
+            f"{segment_results['mean_length']:.4f}", 
+            f"{segment_results['max_change']:.4f}",
+            f"{segment_results['cv']:.2f}", 
+            is_rigid_abs,
+            is_rigid_cv
+        ])
+
+    # Create table
+    cell_colors = []
+    for row in table_data:
+        is_rigid_abs = row[5]
+        is_rigid_cv = row[6]
+        
+        if is_rigid_abs == "Yes" and is_rigid_cv == "Yes":
+            # Both methods say it's rigid - green
+            cell_colors.append(["w", "w", "w", "w", "w", "lightgreen", "lightgreen"])
+        elif is_rigid_abs == "No" and is_rigid_cv == "No":
+            # Both methods say it's not rigid - red
+            cell_colors.append(["w", "w", "w", "w", "w", "lightcoral", "lightcoral"])
+        else:
+            # Methods disagree - yellow highlight where rigidity is claimed
+            colors = ["w", "w", "w", "w", "w", "w", "w"]
+            colors[5] = "lightgreen" if is_rigid_abs == "Yes" else "lightcoral"
+            colors[6] = "lightgreen" if is_rigid_cv == "Yes" else "lightcoral"
+            cell_colors.append(colors)
+
+    plt.table(
+        cellText=table_data,
+        colLabels=headers,
+        loc='center',
+        cellColours=cell_colors,
+        cellLoc='center'
+    )
+
+    # Add a specific test for spine only
+    if 'spine' in results:
+        plt.figure(figsize=(12, 8))
+        spine_results = results['spine']
+        
+        # Plot spine length over time
+        plt.subplot(3, 1, 1)
+        plt.plot(spine_results['lengths'], 'b-', linewidth=2)
+        plt.axhline(y=spine_results['mean_length'], color='r', linestyle='--', 
+                   label=f"Mean: {spine_results['mean_length']:.4f}")
+        plt.axhline(y=spine_results['expected_length'], color='g', linestyle=':', 
+                   label=f"First frame: {spine_results['expected_length']:.4f}")
+        plt.fill_between(range(len(spine_results['lengths'])), 
+                        spine_results['mean_length'] - spine_results['std_deviation'], 
+                        spine_results['mean_length'] + spine_results['std_deviation'], 
+                        color='r', alpha=0.2, 
+                        label=f"±1 Std: {spine_results['std_deviation']:.4f}")
+        plt.title("Spine Length Variation Over Time")
+        plt.xlabel("Frame")
+        plt.ylabel("Length (units)")
+        plt.legend()
+        plt.grid(True, alpha=0.3)
+        
+        # Plot deviation from first frame
+        plt.subplot(3, 1, 2)
+        deviations = np.abs(spine_results['lengths'] - spine_results['expected_length'])
+        plt.plot(deviations, 'r-', linewidth=2)
+        plt.axhline(y=tolerance, color='k', linestyle='--', 
+                   label=f"{tolerance}m threshold")
+        plt.title("Absolute Deviation from First Frame (Original Method)")
+        plt.xlabel("Frame")
+        plt.ylabel("Deviation (units)")
+        plt.legend()
+        plt.grid(True, alpha=0.3)
+        
+        # Plot frame-to-frame changes
+        plt.subplot(3, 1, 3)
+        frame_diffs = np.abs(spine_results['lengths'][1:] - spine_results['lengths'][:-1])
+        plt.plot(range(1, len(spine_results['lengths'])), frame_diffs, 'g-')
+        plt.axhline(y=np.nanmean(frame_diffs), color='r', linestyle='--', 
+                   label=f"Mean change: {np.nanmean(frame_diffs):.6f}")
+        plt.title("Frame-to-Frame Changes in Spine Length")
+        plt.xlabel("Frame")
+        plt.ylabel("Absolute Change")
+        plt.yscale('log')  # Using log scale to better visualize small changes
+        plt.legend()
+        plt.grid(True, alpha=0.3)
+        
+        plt.tight_layout()
+
+
+def print_results_summary(results, segment_data, tolerance=0.001, cv_threshold=0.5):
+    """Print a summary of the rigid bones test results"""
+    
+    total_segments = len(segment_data)
+    rigid_segments_abs = sum(1 for _, r in results.items() if not r['violates_rigidity'])
+    rigid_segments_cv = sum(1 for _, r in results.items() if not r['violates_cv'])
+
+    print(f"\nRigid Bones Test Results:")
+    print(f"- Total segments analyzed: {total_segments}")
+    print(f"- Segments passing {tolerance}m test: {rigid_segments_abs} ({rigid_segments_abs/total_segments*100:.1f}%)")
+    print(f"- Segments passing {cv_threshold}% CV test: {rigid_segments_cv} ({rigid_segments_cv/total_segments*100:.1f}%)")
+
+    # If any segments failed, print their details
+    segments_failing_abs = [s for s, r in results.items() if r['violates_rigidity']]
+
+    if segments_failing_abs:
+        print("\nSegments failing 1mm test (original method):")
+        for segment_name in segments_failing_abs:
+            r = results[segment_name]
+            print(f"- {segment_name}:")
+            print(f"  First frame length: {r['expected_length']:.4f}")
+            print(f"  Mean length: {r['mean_length']:.4f}")
+            print(f"  Max deviation: {r['max_change']:.4f} (Threshold: {tolerance})")
+            print(f"  CV: {r['cv']:.2f}%")
+
+    # Special focus on the spine
+    if 'spine' in results:
+        spine_results = results['spine']
+        print("\nSPINE ANALYSIS:")
+        print(f"- Length in first frame: {spine_results['expected_length']:.4f}")
+        print(f"- Mean length: {spine_results['mean_length']:.4f}")
+        print(f"- Maximum deviation from first frame: {spine_results['max_change']:.4f}")
+        print(f"- Standard deviation: {spine_results['std_deviation']:.4f}")
+        print(f"- Coefficient of variation: {spine_results['cv']:.2f}%")
+        print(f"- Absolute range (max-min): {spine_results['absolute_range']:.4f}")
+        print(f"- Is rigid by {tolerance}m threshold: {'Yes' if not spine_results['violates_rigidity'] else 'No'}")
+        print(f"- Is rigid by {cv_threshold}% CV threshold: {'Yes' if not spine_results['violates_cv'] else 'No'}")
+
+
+def test_rigid_bones(human, tolerance=0.001, cv_threshold=0.5):
+    """
+    Main function to test the rigidity of all bones in a human model.
+    
+    Parameters:
+        human: Human object with trajectory and anatomical structure data
+        tolerance: Tolerance for absolute deviation (in meters)
+        cv_threshold: Threshold for coefficient of variation (%)
+        
+    Returns:
+        Tuple of (results, segment_data)
+    """
+    # Get the data needed for testing
+    trajectory_data = human.body.trajectories['rigid_3d_xyz'].data
+    segment_connections = human.body.anatomical_structure.segment_connections
+    
+    # Create segment data for testing
+    segment_data = create_segment_data(
+        trajectory_data=trajectory_data,
+        segment_connections=segment_connections
+    )
+    
+    # Run the rigidity check
+    results = check_all_rigid_segments(
+        segment_data=segment_data,
+        tolerance=tolerance
+    )
+    
+    # Visualize the results
+    visualize_rigid_bones_results(
+        results=results,
+        tolerance=tolerance,
+        cv_threshold=cv_threshold
+    )
+    
+    # Print a summary of the results
+    print_results_summary(
+        results=results,
+        segment_data=segment_data,
+        tolerance=tolerance,
+        cv_threshold=cv_threshold
+    )
+    
+    return results, segment_data
+
+
+if __name__ == "__main__":
+    # Load data
+    model_info = MediapipeModelInfo()
+    path_to_data = Path(r"C:\Users\aaron\FreeMocap_Data\recording_sessions\freemocap_test_data_v1_5_1\output_data\raw_data\mediapipe_3dData_numFrames_numTrackedPoints_spatialXYZ.npy")
+    data = np.load(path_to_data)
+    
+    # Create Human object
+    human = Human(
+                name="human_one", 
+                model_info=model_info
+                )
+    human.add_tracked_points_numpy(tracked_points_numpy_array=data)
+    
+    # Run calculations (includes rigid bones)
+    human.calculate()
+    
+    # Test rigid bones
+    results, segment_data = test_rigid_bones(human)
+    
+    plt.show()

--- a/skellymodels/experimental/model_redo/tracker_info/mediapipe_info.yaml
+++ b/skellymodels/experimental/model_redo/tracker_info/mediapipe_info.yaml
@@ -148,6 +148,9 @@ aspects:
       right_heel:
         proximal: right_ankle
         distal: right_heel
+      left_heel:
+        proximal: left_ankle
+        distal: left_heel
       right_foot_bottom: 
         proximal: right_heel
         distal: right_foot_index


### PR DESCRIPTION
Two small changes 

1) Adding segment and total body center of mass to CSV. Or more accurately, the CSV now adds in all existing trajectories (before it was just looking for the `3d_xyz` ones). As a note - I excluded `rigid_3d_xyz` from the CSV for now, since those will be handled differently in the future and I didn't want to essentially double the size of the CSV unnecessarily at the moment. The CSV now has a `type` column that notes what kind of trajectory it is. 

2) Updated naming convention for the `model` column so it goes `tracker.model_name` instead of `tracker_model_name`. This was based on something Jon mentioned awhile back which I think was a good idea, because it can help with parsing the columns/data better in the future. For example, for something like `mediapipe.left_hand`, it's easier to split the tracker from the model because you can just split at the period, whereas with the existing `mediapipe_left_hand`, you'd have to be specific about *which* underscore you want to split at so you don't accidentally mess that up. 